### PR TITLE
Memoize it

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,15 @@
 
 var uppercasePattern = /[A-Z]/g;
 var msPattern = /^ms-/;
+var cache = {};
 
 function hyphenateStyleName(string) {
-    return string
-        .replace(uppercasePattern, '-$&')
-        .toLowerCase()
-        .replace(msPattern, '-ms-');
+  return string in cache
+    ? cache[string]
+    : cache[string] = string
+      .replace(uppercasePattern, '-$&')
+      .toLowerCase()
+      .replace(msPattern, '-ms-');
 }
 
 module.exports = hyphenateStyleName;


### PR DESCRIPTION
This function gets called a _lot_ when included in libraries like inline-style-prefixer in single-page-apps. Memoizing it gives a small but noticeable performance increase in complex dynamic UIs using css-in-js.
