### PR TITLE
Support typescript definitions out of the box

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Hyphenates a camelcased CSS property name
+ */
+declare function hyphenateStyleName(name: string): string;
+
+export = hyphenateStyleName;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Hyphenates a camelcased CSS property name",
   "main": "index.cjs.js",
   "module": "index.js",
+  "types": "index.d.ts",
   "sideEffects": false,
   "scripts": {
     "build": "rollup --input index.js --file index.cjs.js --format cjs",
@@ -16,7 +17,8 @@
   },
   "files": [
     "index.js",
-    "index.cjs.js"
+    "index.cjs.js",
+    "index.d.ts"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently we have to install both hyphenate-style-name and @types/hyphenate-style-name to make it work in typescript project. Here I suggest to publish those typings out of the box.